### PR TITLE
Fix minimum and maximum input value settings not localizable

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -48,6 +48,8 @@ var Select2Component = Ember.Component.extend({
   typeaheadSearchingText: 'Searching…',
   typeaheadNoMatchesText: 'No matches found',
   typeaheadErrorText: 'Loading failed',
+  typeaheadMinimumValueText: 'Type more characters…',
+  typeaheadMaximumValueText: 'Type less characters…',
   searchEnabled: true,
   minimumInputLength: null,
   maximumInputLength: null,
@@ -266,6 +268,32 @@ var Select2Component = Ember.Component.extend({
       var text = self.get('typeaheadErrorText');
 
       return Ember.String.htmlSafe(Ember.String.fmt(text, errorThrown));
+    };
+
+    /*
+      Format the no input too short message, substituting the %@ placeholder with
+      the missing chars count left
+     */
+    options.formatInputTooShort = function(textInput, minCount) {
+      var text = self.get('typeaheadMinimumValueText');
+      if (text instanceof Ember.Handlebars.SafeString) {
+        text = text.string;
+      }
+
+      return Ember.String.htmlSafe(Ember.String.fmt(text, minCount));
+    };
+
+    /*
+      Format the input too long message, substituting the %@ placeholder with
+      the count of extra chars
+     */
+    options.formatInputTooLong = function(textInput, maxCount) {
+      var text = self.get('typeaheadMaximumValueText');
+      if (text instanceof Ember.Handlebars.SafeString) {
+        text = text.string;
+      }
+
+      return Ember.String.htmlSafe(Ember.String.fmt(text, maxCount));
     };
 
     /*

--- a/tests/dummy/app/templates/examples.hbs
+++ b/tests/dummy/app/templates/examples.hbs
@@ -225,6 +225,7 @@
           typeaheadSearchingText="Searching pizzas"
           typeaheadNoMatchesText="No pizzas found for '%@'"
           typeaheadErrorText="Loading failed: %@"
+          typeaheadMinimumValueText="Need more than %@ chars..."
           minimumInputLength=3
           maximumInputLength=10
           query="queryPizzas"
@@ -236,6 +237,7 @@
     typeaheadSearchingText="Searching pizzas"
     typeaheadNoMatchesText="No pizzas found for '%@'"
     typeaheadErrorText="Loading failed: %@"
+    typeaheadMinimumValueText="Need more than %@ chars..."
     minimumInputLength=3
     maximumInputLength=10
     query="queryPizzas"

--- a/tests/unit/components/select-2-typeahead-test.js
+++ b/tests/unit/components/select-2-typeahead-test.js
@@ -260,7 +260,7 @@ test("it displays default minimumInputLength text", function(assert) {
   click('.select2-choice');
 
   andThen(function() {
-    assert.equal($('li.select2-no-results').text(), "Please enter 3 or more characters", "displays minimumInputLength text info");
+    assert.equal($('li.select2-no-results').text(), "Type more characters…", "displays minimumInputLength text info");
   });
 });
 
@@ -378,7 +378,7 @@ test("it displays custom `typeaheadNoMatchesText` text", function(assert) {
 
   fillIn('.select2-input', 'body', 'bla');
 
-  andThen(function() {    
+  andThen(function() {
     assert.equal($('li.select2-no-results').text(), "No results for ", "display custom no results text");
   });
 });


### PR DESCRIPTION
This allow implementer of select2 to provide a different translation for typeaheadMinimumValueText and typeaheadMaximumValueText.
