### PR TITLE
Add “clearDefaultValue” property without breaking existing behavior

### DIFF
--- a/addon/components/select-2.js
+++ b/addon/components/select-2.js
@@ -1,6 +1,7 @@
 import Ember from "ember";
 
 var get = Ember.get;
+var getWithDefault = Ember.getWithDefault;
 var run = Ember.run;
 
 /**
@@ -46,6 +47,7 @@ var Select2Component = Ember.Component.extend({
   placeholder: null,
   multiple: false,
   allowClear: false,
+  clearDefaultValue: undefined,
   enabled: true,
   query: null,
   typeaheadSearchingText: 'Searching…',
@@ -515,7 +517,7 @@ var Select2Component = Ember.Component.extend({
         value = Ember.A(data).getEach(optionValuePath);
       } else {
         // treat data as a single object
-        value = get(data, optionValuePath);
+        value = getWithDefault(data, optionValuePath, this.get("clearDefaultValue"));
       }
     } else {
       value = data;


### PR DESCRIPTION
When the selected option is cleared, `data` becomes `null`. But when we also use the `optionValuePath` property, we try to get the specified property on `null` which results to `undefined` — which sometimes isn’t what we want (eg. we might want `null` instead`).

So now we can use `clearDefaultValue: null` when we instantiate the component to get that behavior. The default behavior remains the same with `undefined` being set.
